### PR TITLE
Fix Ubuntu 16 g++ compiles

### DIFF
--- a/src/log.cpp
+++ b/src/log.cpp
@@ -2,6 +2,7 @@
 // Distributed under MIT License
 #include <stdlib.h>
 #include <vector>
+#include <cstring>
 #include <string>
 #include "log.hpp"
 


### PR DESCRIPTION
Minor tweak that fixes compiles with g++ under Ubuntu 16 via:
`c++ *.cpp -std=c++17 -o tasm6801`